### PR TITLE
add: script tag to load analytics script

### DIFF
--- a/3.x/index.html
+++ b/3.x/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="./css/site.css" />
     <link rel="stylesheet" href="./css/print.css" media="print" />
     <script src="./js/apache-maven-fluido-1.8.min.js"></script>
+    <script type="text/javascript" src="https://logging.apache.org/js/analytics.js"></script>
   </head>
   <body class="topBarDisabled">
     <div class="container-fluid">


### PR DESCRIPTION
This adds a script tag to load the analytics script from https://logging.apache.org/js/ once this [PR](https://github.com/apache/logging-site/pull/5) gets merged.

This aims to keep all the analytics logic in one place.

This is part of our work at [Neighbourhoodie/](https://neighbourhood.ie/) with STF's [Bug Resilience Program](https://www.sovereigntechfund.de/programs/bug-resilience) for Log4j.